### PR TITLE
Add AdsrEnvelope class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.pio/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pio/
 .vscode/
+TFT_eSPI/

--- a/adsr/AdsrEnvelope.cpp
+++ b/adsr/AdsrEnvelope.cpp
@@ -1,0 +1,63 @@
+#include <Arduino.h>
+#include "AdsrEnvelope.h"
+
+AdsrEnvelope::AdsrEnvelope(double envelopeMax, double attackDurationMs, double decayDurationMs, double sustainDurationMs, 
+    double sustainMax, double releaseDurationMs) {
+    this->envelopeMax = envelopeMax;
+    this->attackDurationMs = attackDurationMs;
+    this->decayDurationMs = decayDurationMs;
+    this->sustainDurationMs = sustainDurationMs;
+    this->sustainMax = sustainMax;
+    this->releaseDurationMs = releaseDurationMs;
+
+    this->attackShapeFactor = 5.0;
+    this->decayShapeFactor = 10.0;
+    this->releaseShapeFactor = 1.0;
+}
+
+double AdsrEnvelope::getEnvelopeValue(double time) {
+    double envelopeValue = 0.0;
+    double timeSinceStart = time - this->envelopeStartTime;
+    if (timeSinceStart < this->attackDurationMs) {
+        // attack phase
+        double phaseTime = timeSinceStart;
+        if (attackShapeFactor < 5.0) {
+            // linear
+            envelopeValue = envelopeMax * (phaseTime / attackDurationMs);
+        } else {
+            // exponential
+            double tau = attackDurationMs / attackShapeFactor;
+            envelopeValue = envelopeMax * (1.0 - exp(-phaseTime / tau));
+        }
+    } else if (timeSinceStart < this->attackDurationMs + this->decayDurationMs) {
+        // decay phase
+        double phaseTime = timeSinceStart - this->attackDurationMs;
+        if (attackShapeFactor < 5.0) {
+            // linear
+            envelopeValue = sustainMax + (envelopeMax - sustainMax) * (1.0 - phaseTime / decayDurationMs);
+        } else {
+            // exponential
+            double tau = decayDurationMs / decayShapeFactor;
+            envelopeValue = sustainMax + (envelopeMax - sustainMax) * exp(-phaseTime / tau);
+        }
+    } else if (timeSinceStart < this->attackDurationMs + this->decayDurationMs + this->sustainDurationMs) {
+        // sustain phase
+        envelopeValue = this->sustainMax;
+    } else if (timeSinceStart < 
+            this->attackDurationMs + this->decayDurationMs + this->sustainDurationMs + this->releaseDurationMs) {
+        // release phase
+        double phaseTime = timeSinceStart - this->attackDurationMs - this->decayDurationMs - this->sustainDurationMs;
+        if (releaseShapeFactor < 6.0) {
+            // linear
+            envelopeValue = this->sustainMax * (1.0 - phaseTime / releaseDurationMs);
+        } else {
+            // exponential
+            double tau = releaseDurationMs / releaseShapeFactor;
+            envelopeValue = this->sustainMax * exp(-phaseTime / tau);
+        }
+    } else {
+        envelopeValue = 0.0;
+    }
+    return envelopeValue;
+}
+

--- a/adsr/AdsrEnvelope.cpp
+++ b/adsr/AdsrEnvelope.cpp
@@ -61,3 +61,16 @@ double AdsrEnvelope::getEnvelopeValue(double time) {
     return envelopeValue;
 }
 
+void AdsrEnvelope::setEnvelopeDurationMs(double envelopeDurationMs) {
+    double attackDurationMs = this->attackDurationMs;
+    double decayDurationMs = this->decayDurationMs;
+    double sustainDurationMs = this->sustainDurationMs;
+    double releaseDurationMs = this->releaseDurationMs;
+
+    double ratio = envelopeDurationMs / getEnvelopeDurationMs();
+
+    this->attackDurationMs = attackDurationMs * ratio;
+    this->decayDurationMs = decayDurationMs * ratio;
+    this->sustainDurationMs = sustainDurationMs * ratio;
+    this->releaseDurationMs = releaseDurationMs * ratio;
+}

--- a/adsr/AdsrEnvelope.h
+++ b/adsr/AdsrEnvelope.h
@@ -30,6 +30,7 @@ public:
     inline void setSustainDurationMs(double sustainDurationMs) { this->sustainDurationMs = sustainDurationMs; }
     inline void setReleaseDurationMs(double releaseDurationMs) { this->releaseDurationMs = releaseDurationMs; }
     inline void setReleaseShapeFactor(double releaseShapeFactor) { this->releaseShapeFactor = releaseShapeFactor; }
+    void setEnvelopeDurationMs(double envelopeDurationMs);
 
     inline double getEnvelopeStartTime() { return envelopeStartTime; }
     inline double getEnvelopeMax() { return envelopeMax; }

--- a/adsr/AdsrEnvelope.h
+++ b/adsr/AdsrEnvelope.h
@@ -30,6 +30,7 @@ public:
     inline void setReleaseDurationMs(double releaseDurationMs) { this->releaseDurationMs = releaseDurationMs; }
     inline void setReleaseShapeFactor(double releaseShapeFactor) { this->releaseShapeFactor = releaseShapeFactor; }
 
+    inline double getEnvelopeStartTime() { return envelopeStartTime; }
     inline double getEnvelopeDurationMs() { return attackDurationMs + decayDurationMs + sustainDurationMs + releaseDurationMs; }
 };
 #endif

--- a/adsr/AdsrEnvelope.h
+++ b/adsr/AdsrEnvelope.h
@@ -1,4 +1,5 @@
 #ifndef ADSR_ENVELOPE_H
+#define ADSR_ENVELOPE_H
 
 class AdsrEnvelope {
 private:

--- a/adsr/AdsrEnvelope.h
+++ b/adsr/AdsrEnvelope.h
@@ -1,0 +1,35 @@
+#ifndef ADSR_ENVELOPE_H
+
+class AdsrEnvelope {
+private:
+    double envelopeMax;
+    double attackShapeFactor;
+    double attackDurationMs;
+    double envelopeStartTime;
+    double decayDurationMs;
+    double decayShapeFactor;
+    double sustainDurationMs;
+    double sustainMax;
+    double releaseDurationMs;
+    double releaseShapeFactor;
+
+public:
+    AdsrEnvelope(double envelopeMax, double attackDurationMs, double decayDurationMs, double sustainDurationMs, 
+        double sustainMax, double releaseDurationMs);
+    
+    inline void setEnvelopeStartTime(double time) { this->envelopeStartTime = time; }
+
+    double getEnvelopeValue(double time);
+
+    inline void setEnvelopeMax(double envelopeMax) { this->envelopeMax = envelopeMax; }
+    inline void setAttackShapeFactor(double attackShapeFactor) { this->attackShapeFactor = attackShapeFactor; }
+    inline void setAttackDurationMs(double attackDurationMs) { this->attackDurationMs = attackDurationMs; }
+    inline void setdecayDurationMs(double decayDurationMs) { this->decayDurationMs = decayDurationMs; }
+    inline void setdecayShapeFactor(double decayShapeFactor) { this->decayShapeFactor = decayShapeFactor; }
+    inline void setSustainDurationMs(double sustainDurationMs) { this->sustainDurationMs = sustainDurationMs; }
+    inline void setReleaseDurationMs(double releaseDurationMs) { this->releaseDurationMs = releaseDurationMs; }
+    inline void setReleaseShapeFactor(double releaseShapeFactor) { this->releaseShapeFactor = releaseShapeFactor; }
+
+    inline double getEnvelopeDurationMs() { return attackDurationMs + decayDurationMs + sustainDurationMs + releaseDurationMs; }
+};
+#endif

--- a/adsr/AdsrEnvelope.h
+++ b/adsr/AdsrEnvelope.h
@@ -31,6 +31,13 @@ public:
     inline void setReleaseShapeFactor(double releaseShapeFactor) { this->releaseShapeFactor = releaseShapeFactor; }
 
     inline double getEnvelopeStartTime() { return envelopeStartTime; }
+    inline double getEnvelopeMax() { return envelopeMax; }
+    inline double getAttackShapeFactor() { return attackShapeFactor; }
+    inline double getAttackDurationMs() { return attackDurationMs; }
+    inline double getDecayDurationMs() { return decayDurationMs; }
+    inline double getDecayShapeFactor() { return decayShapeFactor; }
+    inline double getSustainDurationMs() { return sustainDurationMs; }
+    inline double getSustainMax() { return sustainMax; }
     inline double getEnvelopeDurationMs() { return attackDurationMs + decayDurationMs + sustainDurationMs + releaseDurationMs; }
 };
 #endif

--- a/adsr/Display.cpp
+++ b/adsr/Display.cpp
@@ -15,6 +15,14 @@ void Display::init() {
     Serial.println("Display initialized");
 }
 
+void Display::draw(AdsrEnvelope* adsr) {
+    drawChart(adsr);
+    drawCaption(adsr);
+
+    chartSprite.pushSprite(0, 0);
+    captionSprite.pushSprite(0, screenHeight - CAPTION_AREA_HEIGHT);
+}
+
 void Display::drawChart(AdsrEnvelope* adsr) {
     chartSprite.fillSprite(TFT_BLACK);
 
@@ -39,7 +47,9 @@ void Display::drawChart(AdsrEnvelope* adsr) {
     captionSprite.setTextFont(1);
     captionSprite.setTextSize(2);
     captionSprite.setTextColor(TFT_WHITE, TFT_BLACK);
+}
 
+void Display::drawCaption(AdsrEnvelope* adsr) {
     char buffer[20];
     snprintf(buffer, sizeof(buffer), "%s: %.1fs", "Attack", adsr->getAttackDurationMs() / 1000.0);
     String leftString = String(buffer);
@@ -50,11 +60,6 @@ void Display::drawChart(AdsrEnvelope* adsr) {
     captionSprite.drawString(leftString, 6, 6);
     int16_t rightX = captionSprite.width() - captionSprite.textWidth(rightString) - 6;
     captionSprite.drawString(rightString, rightX, 6);
-
-    chartSprite.pushSprite(0, 0);
-    captionSprite.pushSprite(0, screenHeight - CAPTION_AREA_HEIGHT);
-
-    Serial.println("Chart drawn");
 }
 
 

--- a/adsr/Display.cpp
+++ b/adsr/Display.cpp
@@ -1,0 +1,36 @@
+#include "Display.h"
+
+Display::Display(int width, int height) : screenWidth(width), screenHeight(height), tft() {
+    buffer = (uint16_t*)malloc(screenWidth * screenHeight * sizeof(uint16_t));
+}
+
+void Display::init() {
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, HIGH);
+    tft.init();
+    tft.setRotation(3);
+    Serial.println("Display initialized");
+}
+
+void Display::drawChart(AdsrEnvelope* adsr) {
+    memset (buffer, 0, screenWidth * screenHeight * sizeof(uint16_t));
+
+    for (int i = 0; i < screenWidth; i++) {
+        double time = adsr->getEnvelopeStartTime() + i * adsr->getEnvelopeDurationMs() / screenWidth;
+        double envelopeValue = adsr->getEnvelopeValue(time);
+
+        int x = screenWidth - 1 - i;
+        int y = (int)(envelopeValue * screenHeight / adsr->getEnvelopeMax());
+        buffer[x + y * screenWidth] = TFT_WHITE;
+        // Serial.print("[");
+        // Serial.print(x);
+        // Serial.print(", ");
+        // Serial.print(y);
+        // Serial.print("] ");
+    }
+
+    tft.pushImage(0, 0, screenWidth, screenHeight, buffer);
+    Serial.println("Chart drawn");
+}
+
+

--- a/adsr/Display.cpp
+++ b/adsr/Display.cpp
@@ -1,7 +1,7 @@
 #include "Display.h"
 
-Display::Display(int width, int height) : screenWidth(width), screenHeight(height), tft() {
-    buffer = (uint16_t*)malloc(screenWidth * screenHeight * sizeof(uint16_t));
+Display::Display(int width, int height) : screenWidth(width), screenHeight(height), tft(), chartSprite(&tft) {
+    chartSprite.createSprite(screenWidth, screenHeight);
 }
 
 void Display::init() {
@@ -13,7 +13,10 @@ void Display::init() {
 }
 
 void Display::drawChart(AdsrEnvelope* adsr) {
-    memset (buffer, 0, screenWidth * screenHeight * sizeof(uint16_t));
+    chartSprite.fillSprite(TFT_BLACK);
+
+    int xPrev = 0;
+    int yPrev = -1;
 
     for (int i = 0; i < screenWidth; i++) {
         double time = adsr->getEnvelopeStartTime() + i * adsr->getEnvelopeDurationMs() / screenWidth;
@@ -21,7 +24,14 @@ void Display::drawChart(AdsrEnvelope* adsr) {
 
         int x = screenWidth - 1 - i;
         int y = (int)(envelopeValue * screenHeight / adsr->getEnvelopeMax());
-        buffer[x + y * screenWidth] = TFT_WHITE;
+
+        if (yPrev > 0) {
+          chartSprite.drawLine(xPrev, yPrev, x, y, TFT_WHITE);
+        }
+
+        xPrev = x;
+        yPrev = y;
+
         // Serial.print("[");
         // Serial.print(x);
         // Serial.print(", ");
@@ -29,7 +39,8 @@ void Display::drawChart(AdsrEnvelope* adsr) {
         // Serial.print("] ");
     }
 
-    tft.pushImage(0, 0, screenWidth, screenHeight, buffer);
+    chartSprite.pushSprite(0, 0);
+
     Serial.println("Chart drawn");
 }
 

--- a/adsr/Display.cpp
+++ b/adsr/Display.cpp
@@ -15,9 +15,9 @@ void Display::init() {
     Serial.println("Display initialized");
 }
 
-void Display::draw(AdsrEnvelope* adsr) {
+void Display::draw(AdsrEnvelope* adsr, EncoderHandler* encoderHandler) {
     drawChart(adsr);
-    drawCaption(adsr);
+    drawCaption(adsr, encoderHandler);
 
     chartSprite.pushSprite(0, 0);
     captionSprite.pushSprite(0, screenHeight - CAPTION_AREA_HEIGHT);
@@ -49,17 +49,26 @@ void Display::drawChart(AdsrEnvelope* adsr) {
     captionSprite.setTextColor(TFT_WHITE, TFT_BLACK);
 }
 
-void Display::drawCaption(AdsrEnvelope* adsr) {
+void Display::drawCaption(AdsrEnvelope* adsr, EncoderHandler* encoderHandler) {
     char buffer[20];
-    snprintf(buffer, sizeof(buffer), "%s: %.1fs", "Attack", adsr->getAttackDurationMs() / 1000.0);
+    switch(encoderHandler->getState()) {
+        case EncoderHandler::ATTACK_DURATION:
+            snprintf(buffer, sizeof(buffer), "%s: %.1fs", "Attack", adsr->getAttackDurationMs() / 1000.0);
+            break;
+        case EncoderHandler::ATTACK_SHAPE:
+            if (adsr->getAttackShapeFactor() < 5) {
+                snprintf(buffer, sizeof(buffer), "%s: %s", "Shape", "Linear");
+            } else {
+                snprintf(buffer, sizeof(buffer), "%s: %.f", "Shape", adsr->getAttackShapeFactor());
+            }
+            break;
+        case EncoderHandler::ENVELOPE_DURATION:
+            snprintf(buffer, sizeof(buffer), "%s: %.1fs", "Envelope", adsr->getEnvelopeDurationMs() / 1000.0);
+            break;
+
+    }
     String leftString = String(buffer);
-
-    snprintf(buffer, sizeof(buffer), "%.1fs", adsr->getEnvelopeDurationMs() / 1000.0);
-    String rightString = String(buffer);
-
     captionSprite.drawString(leftString, 6, 6);
-    int16_t rightX = captionSprite.width() - captionSprite.textWidth(rightString) - 6;
-    captionSprite.drawString(rightString, rightX, 6);
 }
 
 

--- a/adsr/Display.cpp
+++ b/adsr/Display.cpp
@@ -1,14 +1,17 @@
 #include "Display.h"
 
-Display::Display(int width, int height) : screenWidth(width), screenHeight(height), tft(), chartSprite(&tft) {
-    chartSprite.createSprite(screenWidth, screenHeight);
+Display::Display(uint16_t width, uint16_t height) : screenWidth(width), screenHeight(height), tft(), 
+        chartSprite(&tft), captionSprite(&tft) {
+    chartHeight = screenHeight - CAPTION_AREA_HEIGHT;
+    chartSprite.createSprite(screenWidth, chartHeight);
+    captionSprite.createSprite(screenWidth, CAPTION_AREA_HEIGHT);
 }
 
 void Display::init() {
     pinMode(TFT_BL, OUTPUT);
     digitalWrite(TFT_BL, HIGH);
     tft.init();
-    tft.setRotation(3);
+    tft.setRotation(1);
     Serial.println("Display initialized");
 }
 
@@ -18,12 +21,11 @@ void Display::drawChart(AdsrEnvelope* adsr) {
     int xPrev = 0;
     int yPrev = -1;
 
-    for (int i = 0; i < screenWidth; i++) {
-        double time = adsr->getEnvelopeStartTime() + i * adsr->getEnvelopeDurationMs() / screenWidth;
+    for (int x = 0; x < screenWidth; x++) {
+        double time = adsr->getEnvelopeStartTime() + x * adsr->getEnvelopeDurationMs() / screenWidth;
         double envelopeValue = adsr->getEnvelopeValue(time);
 
-        int x = screenWidth - 1 - i;
-        int y = (int)(envelopeValue * screenHeight / adsr->getEnvelopeMax());
+        int y = (int)((chartHeight + 1) - (envelopeValue * chartHeight / adsr->getEnvelopeMax()));
 
         if (yPrev > 0) {
           chartSprite.drawLine(xPrev, yPrev, x, y, TFT_WHITE);
@@ -31,15 +33,26 @@ void Display::drawChart(AdsrEnvelope* adsr) {
 
         xPrev = x;
         yPrev = y;
-
-        // Serial.print("[");
-        // Serial.print(x);
-        // Serial.print(", ");
-        // Serial.print(y);
-        // Serial.print("] ");
     }
 
+    captionSprite.fillSprite(TFT_BLACK);
+    captionSprite.setTextFont(1);
+    captionSprite.setTextSize(2);
+    captionSprite.setTextColor(TFT_WHITE, TFT_BLACK);
+
+    char buffer[20];
+    snprintf(buffer, sizeof(buffer), "%s: %.1fs", "Attack", adsr->getAttackDurationMs() / 1000.0);
+    String leftString = String(buffer);
+
+    snprintf(buffer, sizeof(buffer), "%.1fs", adsr->getEnvelopeDurationMs() / 1000.0);
+    String rightString = String(buffer);
+
+    captionSprite.drawString(leftString, 6, 6);
+    int16_t rightX = captionSprite.width() - captionSprite.textWidth(rightString) - 6;
+    captionSprite.drawString(rightString, rightX, 6);
+
     chartSprite.pushSprite(0, 0);
+    captionSprite.pushSprite(0, screenHeight - CAPTION_AREA_HEIGHT);
 
     Serial.println("Chart drawn");
 }

--- a/adsr/Display.h
+++ b/adsr/Display.h
@@ -17,10 +17,12 @@ private:
     TFT_eSprite chartSprite;
     TFT_eSprite captionSprite;
 
+    void drawChart(AdsrEnvelope* adsr);
+    void drawCaption(AdsrEnvelope* adsr);
 
 public:
     Display(uint16_t screenWidth, uint16_t screenHeight);
     void init();
-    void drawChart(AdsrEnvelope* adsr);
+    void draw(AdsrEnvelope* adsr);
 };
 #endif

--- a/adsr/Display.h
+++ b/adsr/Display.h
@@ -9,13 +9,17 @@
 
 class Display {
 private:
-    int screenWidth;
-    int screenHeight;
+    const uint16_t CAPTION_AREA_HEIGHT = 26;
+    uint16_t screenWidth;
+    uint16_t screenHeight;
+    uint16_t chartHeight;
     TFT_eSPI tft;
     TFT_eSprite chartSprite;
+    TFT_eSprite captionSprite;
+
 
 public:
-    Display(int screenWidth, int screenHeight);
+    Display(uint16_t screenWidth, uint16_t screenHeight);
     void init();
     void drawChart(AdsrEnvelope* adsr);
 };

--- a/adsr/Display.h
+++ b/adsr/Display.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <TFT_eSPI.h>
 #include "AdsrEnvelope.h"
+#include "EncoderHandler.h"
 
 #define TFT_BL   4 // Display backlight control pin
 
@@ -18,11 +19,11 @@ private:
     TFT_eSprite captionSprite;
 
     void drawChart(AdsrEnvelope* adsr);
-    void drawCaption(AdsrEnvelope* adsr);
+    void drawCaption(AdsrEnvelope* adsr, EncoderHandler* encoderHandler);
 
 public:
     Display(uint16_t screenWidth, uint16_t screenHeight);
     void init();
-    void draw(AdsrEnvelope* adsr);
+    void draw(AdsrEnvelope* adsr, EncoderHandler* encoderHandler);
 };
 #endif

--- a/adsr/Display.h
+++ b/adsr/Display.h
@@ -1,0 +1,22 @@
+#ifndef DISPLAY_H
+#define DISPLAY_H
+
+#include <Arduino.h>
+#include <TFT_eSPI.h>
+#include "AdsrEnvelope.h"
+
+#define TFT_BL   4 // Display backlight control pin
+
+class Display {
+private:
+    int screenWidth;
+    int screenHeight;
+    uint16_t* buffer;
+    TFT_eSPI tft;
+
+public:
+    Display(int screenWidth, int screenHeight);
+    void init();
+    void drawChart(AdsrEnvelope* adsr);
+};
+#endif

--- a/adsr/Display.h
+++ b/adsr/Display.h
@@ -11,8 +11,8 @@ class Display {
 private:
     int screenWidth;
     int screenHeight;
-    uint16_t* buffer;
     TFT_eSPI tft;
+    TFT_eSprite chartSprite;
 
 public:
     Display(int screenWidth, int screenHeight);

--- a/adsr/EncoderHandler.cpp
+++ b/adsr/EncoderHandler.cpp
@@ -65,12 +65,24 @@ void EncoderHandler::tick() {
    }
 }
 
+void EncoderHandler::onPushButtonImpl() {
+    // NB: not okay to call Serial.println method on ESP32 here as it blocks.
+
+    // simple debounce
+    if (millis() - lastButtonClickTime < 100) {
+        return;
+    }
+    lastButtonClickTime = millis();
+    encoderState = (EncoderHandler::State)((encoderState + 1) % 2);
+}
+
+
 #if defined(ESP32)
 void IRAM_ATTR EncoderHandler::onPushButton() {
 # else
 void EncoderHandler::onPushButton() {
 #endif
-  // note: not okay to call Serial.println method on ESP32 here as it blocks.
-  // TODO: probably need to debounce.
-  instance->encoderState = (EncoderHandler::State)((instance->encoderState + 1) % 2);
+    if (instance) {
+        instance->onPushButtonImpl();
+    }
 }

--- a/adsr/EncoderHandler.cpp
+++ b/adsr/EncoderHandler.cpp
@@ -58,6 +58,18 @@ void EncoderHandler::tick() {
             Serial.print("Attack shape factor: ");
             Serial.println(attackShapeFactor);
             break;
+        case ENVELOPE_DURATION:
+            double envelopeDurationMs = adsr->getEnvelopeDurationMs();
+            envelopeDurationMs += 50 * encoderDelta;
+            if (envelopeDurationMs > 5000) {
+                envelopeDurationMs = 5000;
+            } else if (envelopeDurationMs < 500) {
+                envelopeDurationMs = 500;
+            }
+            adsr->setEnvelopeDurationMs(envelopeDurationMs);
+            Serial.print("Envelope duration: ");
+            Serial.println(envelopeDurationMs);
+            break;
         }
         if (onEncoderChanged) {
             onEncoderChanged();
@@ -73,7 +85,7 @@ void EncoderHandler::onPushButtonImpl() {
         return;
     }
     lastButtonClickTime = millis();
-    encoderState = (EncoderHandler::State)((encoderState + 1) % 2);
+    encoderState = (EncoderHandler::State)((encoderState + 1) % 3);
 }
 
 

--- a/adsr/EncoderHandler.cpp
+++ b/adsr/EncoderHandler.cpp
@@ -1,0 +1,76 @@
+#include "EncoderHandler.h"
+
+EncoderHandler* EncoderHandler::instance = nullptr;  
+
+EncoderHandler::EncoderHandler(AdsrEnvelope* adsr) : adsr(adsr), encoderState(ATTACK_DURATION) {
+    instance = this;
+}
+
+void EncoderHandler::setup() {
+    pinMode(ENCODER_BUTTON_PIN, INPUT_PULLUP);
+#if defined(ESP32)
+    encoder.attachHalfQuad(ENCODER_A_PIN, ENCODER_B_PIN);
+#endif
+    attachInterrupt(digitalPinToInterrupt(ENCODER_BUTTON_PIN), onPushButton, RISING);
+}
+
+void EncoderHandler::registerOnEncoderChange(void (*callback)()) {
+    onEncoderChanged = callback;
+}
+
+void EncoderHandler::tick() {
+#if defined(ESP32)
+    long newEncoderPosition = encoder.getCount() / 2;
+#else
+    long newEncoderPosition = encoder.read() / 4;
+#endif
+
+    if (newEncoderPosition != encoderPosition) {
+        Serial.print("Encoder position: ");
+        Serial.println(newEncoderPosition);
+
+        long encoderDelta = (newEncoderPosition - encoderPosition);
+        encoderPosition = newEncoderPosition;
+        double attackDurationMs;
+        double attackShapeFactor;
+        switch (encoderState) {
+        case ATTACK_DURATION:
+            attackDurationMs = adsr->getAttackDurationMs();
+            attackDurationMs += 50 * encoderDelta;
+            if (attackDurationMs > 1000) {
+                attackDurationMs = 1000;
+            } else if (attackDurationMs < 50) {
+                attackDurationMs = 50;
+            }
+            adsr->setAttackDurationMs(attackDurationMs);
+            Serial.print("Attack duration: ");
+            Serial.println(attackDurationMs);
+            break;
+        case ATTACK_SHAPE:
+            attackShapeFactor = adsr->getAttackShapeFactor();
+            attackShapeFactor += 0.5 * encoderDelta;
+            if (attackShapeFactor > 10) {
+                attackShapeFactor = 10;
+            } else if (attackShapeFactor < 4) {
+                attackShapeFactor = 4;
+            }
+            adsr->setAttackShapeFactor(attackShapeFactor);
+            Serial.print("Attack shape factor: ");
+            Serial.println(attackShapeFactor);
+            break;
+        }
+        if (onEncoderChanged) {
+            onEncoderChanged();
+        }
+   }
+}
+
+#if defined(ESP32)
+void IRAM_ATTR EncoderHandler::onPushButton() {
+# else
+void EncoderHandler::onPushButton() {
+#endif
+  // note: not okay to call Serial.println method on ESP32 here as it blocks.
+  // TODO: probably need to debounce.
+  instance->encoderState = (EncoderHandler::State)((instance->encoderState + 1) % 2);
+}

--- a/adsr/EncoderHandler.cpp
+++ b/adsr/EncoderHandler.cpp
@@ -33,12 +33,14 @@ void EncoderHandler::tick() {
         encoderPosition = newEncoderPosition;
         double attackDurationMs;
         double attackShapeFactor;
+        double maxAttackDurationMs;
         switch (encoderState) {
         case ATTACK_DURATION:
             attackDurationMs = adsr->getAttackDurationMs();
             attackDurationMs += 50 * encoderDelta;
-            if (attackDurationMs > 1000) {
-                attackDurationMs = 1000;
+            maxAttackDurationMs = adsr->getEnvelopeDurationMs() - 400;
+            if (attackDurationMs > maxAttackDurationMs) {
+                attackDurationMs = maxAttackDurationMs;
             } else if (attackDurationMs < 50) {
                 attackDurationMs = 50;
             }

--- a/adsr/EncoderHandler.cpp
+++ b/adsr/EncoderHandler.cpp
@@ -41,7 +41,8 @@ void EncoderHandler::tick() {
             maxAttackDurationMs = adsr->getEnvelopeDurationMs() - 400;
             if (attackDurationMs > maxAttackDurationMs) {
                 attackDurationMs = maxAttackDurationMs;
-            } else if (attackDurationMs < 50) {
+            }
+            if (attackDurationMs < 50) {
                 attackDurationMs = 50;
             }
             adsr->setAttackDurationMs(attackDurationMs);
@@ -88,6 +89,10 @@ void EncoderHandler::onPushButtonImpl() {
     }
     lastButtonClickTime = millis();
     encoderState = (EncoderHandler::State)((encoderState + 1) % 3);
+
+    if (onEncoderChanged) {
+        onEncoderChanged();
+    }
 }
 
 

--- a/adsr/EncoderHandler.h
+++ b/adsr/EncoderHandler.h
@@ -25,9 +25,11 @@ class EncoderHandler {
 
     enum State {
         ATTACK_DURATION,
-        ATTACK_SHAPE
+        ATTACK_SHAPE,
+        ENVELOPE_DURATION
     };
 
+    inline State getState() { return encoderState; }
     void tick();
     void registerOnEncoderChange(OnEncoderChanged callback);
 

--- a/adsr/EncoderHandler.h
+++ b/adsr/EncoderHandler.h
@@ -35,6 +35,10 @@ class EncoderHandler {
     static EncoderHandler* instance; 
     OnEncoderChanged onEncoderChanged;
     State encoderState;
+    long lastButtonClickTime = 0;
+
+    void onPushButtonImpl();
+    
 #if defined(ESP32)
     ESP32Encoder encoder;
 #else

--- a/adsr/EncoderHandler.h
+++ b/adsr/EncoderHandler.h
@@ -32,6 +32,7 @@ class EncoderHandler {
     inline State getState() { return encoderState; }
     void tick();
     void registerOnEncoderChange(OnEncoderChanged callback);
+    inline State getEncoderState() { return encoderState; }
 
     private: 
     static EncoderHandler* instance; 

--- a/adsr/EncoderHandler.h
+++ b/adsr/EncoderHandler.h
@@ -1,0 +1,55 @@
+#ifndef ENCODER_HANDLER_H
+#define ENCODER_HANDLER_H
+
+#include <Arduino.h>
+#include "AdsrEnvelope.h"
+
+#if defined(ESP32)
+#include <ESP32Encoder.h>
+#define ENCODER_A_PIN 32
+#define ENCODER_B_PIN 33
+#define ENCODER_BUTTON_PIN 26
+#else
+#include <Encoder.h>
+#define ENCODER_A_PIN 5
+#define ENCODER_B_PIN 6
+#define ENCODER_BUTTON_PIN 7
+
+#endif
+
+class EncoderHandler {
+    public:
+    using OnEncoderChanged = void(*)();
+    EncoderHandler(AdsrEnvelope* adsr);
+    void setup();
+
+    enum State {
+        ATTACK_DURATION,
+        ATTACK_SHAPE
+    };
+
+    void tick();
+    void registerOnEncoderChange(OnEncoderChanged callback);
+
+    private: 
+    static EncoderHandler* instance; 
+    OnEncoderChanged onEncoderChanged;
+    State encoderState;
+#if defined(ESP32)
+    ESP32Encoder encoder;
+#else
+    Encoder encoder(ENCODER_A_PIN, ENCODER_B_PIN);
+#endif
+
+    long encoderPosition = 0;
+
+    AdsrEnvelope* adsr;
+
+    #if defined(ESP32)
+    static void IRAM_ATTR onPushButton();
+    # else
+    static void onPushButton();
+    #endif
+};
+
+#endif

--- a/adsr/README.md
+++ b/adsr/README.md
@@ -11,3 +11,21 @@ Using a decay scaling parameter of 10.0 (tau is 1/10 of T_decay)
 Wolfram alpha link: https://www.wolframalpha.com/input?i=Plot%5B2047+%E2%80%8B+%2B+%284095+-+2047%29+*+%28e%5E%28-t%2F50+%29%29%2C+%7Bt%2C+0%2C+500%7D%5D
 
 ![alt text](image-1.png)
+
+
+### Setting up the display:
+I'm using a LilyGo TTGO display. I needed to do two things to get the TFT_eSPI library to work with my board:
+
+1. I had to edit the `TFT_eSPI/User_Setup_Select.h`, commenting out the default include file, e.g.
+> Line 27: `// #include <User_Setup.h>`
+and uncommenting the line for the TTGO_T display.
+> Line 58: `#include <User_Setups/Setup25_TTGO_T_Display.h>`
+
+2. I had to edit `TFT_eSPI/Processors/TFT_eSPI_ESP32.h`, adding the following:
+```
+#if ESP_ARDUINO_VERSION_MAJOR >= 3
+	#include "driver/gpio.h"
+	#include <rom/ets_sys.h>
+#endif
+```
+See: https://github.com/Bodmer/TFT_eSPI/issues/3346

--- a/adsr/adsr.ino
+++ b/adsr/adsr.ino
@@ -39,7 +39,7 @@ void setup() {
   display.init();
   encoderHandler.registerOnEncoderChange(onEncoderChanged);
   encoderHandler.setup();
-  display.draw(&adsr);
+  display.draw(&adsr, &encoderHandler);
 }
 
 void loop() {
@@ -62,5 +62,5 @@ void loop() {
 }
 
 void onEncoderChanged() {
-  display.draw(&adsr);
+  display.draw(&adsr, &encoderHandler);
 }

--- a/adsr/adsr.ino
+++ b/adsr/adsr.ino
@@ -1,4 +1,5 @@
 #include <Encoder.h>
+#include "AdsrEnvelope.h"
 
 #if defined(ESP32)
 #define DAC_BIT_WIDTH 8
@@ -13,28 +14,20 @@ const unsigned long T_decay = 75;     // Decay time in milliseconds
 const unsigned long T_sustain = 250;  // Sustain time in milliseconds
 const unsigned long T_release = 250;  // Release time in milliseconds
 
-// Time constant for exponential attack; Adjust to change shape of the curve.
-const float attack_shape_factor = 5.0;
-
-const float decay_shape_factor = 10.0;
-const float tau_decay = T_decay / decay_shape_factor;
-
-const float release_shape_factor = 1.0;  // low = linear, high = loggy
-const float tau_release = T_release / release_shape_factor;
-
 int envelopeValue = 0;
 unsigned long startTime = 0;
-int stage = 0;  // 0: Attack, 1: Decay, 2: Sustain, 3: Release, 4: Done
 
-Encoder myEnc(5, 6);
+// Encoder myEnc(5, 6);
 const byte switchPin = 7;
 
 long oldPosition = -999;
 
 const byte buzzPin = 3;
 
+AdsrEnvelope adsr(A_max, T_attack, T_decay, T_sustain, A_sustain, T_release);
+
 void setup() {
-  Serial.begin(9600);
+  Serial.begin(115200);
 
 #if defined(ESP32)
   delay(1000);  // wait for Serial on ESP32
@@ -44,97 +37,43 @@ void setup() {
 
   // Initialize the envelope stage
   startTime = millis();
-  stage = 0;
 
   Serial.println("Hello Envelope Generator");
 
-  pinMode(switchPin, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(switchPin), handleSwitch, RISING);
+  // pinMode(switchPin, INPUT_PULLUP);
+  // attachInterrupt(digitalPinToInterrupt(switchPin), handleSwitch, RISING);
 
-  pinMode(buzzPin, OUTPUT);
-  tone(buzzPin, 200);
+  // pinMode(buzzPin, OUTPUT);
+  // tone(buzzPin, 200);
 }
 
 void loop() {
 
-  long newPosition = myEnc.read();
-  if (newPosition != oldPosition) {
-    // Turning knob right position goes down, but want attack to go up
-    if (newPosition < oldPosition) {
-      T_attack = T_attack + 25;
+//   long newPosition = myEnc.read();
+//   if (newPosition != oldPosition) {
+//     // Turning knob right position goes down, but want attack to go up
+//     if (newPosition < oldPosition) {
+//       T_attack = T_attack + 25;
 
-    } else if (newPosition > oldPosition) {
-      if (T_attack >= 25) {
-        T_attack = T_attack - 25;
-      }
-    }
+//     } else if (newPosition > oldPosition) {
+//       if (T_attack >= 25) {
+//         T_attack = T_attack - 25;
+//       }
+//     }
 
-    oldPosition = newPosition;
-    Serial.print("Attack change: ");
-    Serial.println(T_attack);
-  }
-
-
-  float tau_attack = T_attack / attack_shape_factor;
-
-
-
-  // Example: Reset the envelope when a button is pressed
-  //   if (digitalRead(2) == HIGH) {
-  //     startTime = millis();
-  //     stage = 0;
-  //   }
+//     oldPosition = newPosition;
+//     Serial.print("Attack change: ");
+//     Serial.println(T_attack);
+//   }
 
   unsigned long currentTime = millis();
   unsigned long elapsedTime = currentTime - startTime;
-
-  switch (stage) {
-    case 0:  // Attack
-      if (elapsedTime < T_attack) {
-        envelopeValue = A_max * (1 - exp(-(elapsedTime / tau_attack)));
-      } else {
-        envelopeValue = A_max;
-        startTime = currentTime;
-        stage = 1;
-      }
-      break;
-
-    case 1:  // Decay
-      if (elapsedTime < T_decay) {
-        envelopeValue = A_sustain + (A_max - A_sustain) * exp(-(elapsedTime / tau_decay));
-      } else {
-        envelopeValue = A_sustain;
-        startTime = currentTime;
-        stage = 2;
-      }
-      break;
-
-    case 2:  // Sustain
-      if (elapsedTime < T_sustain) {
-        envelopeValue = A_sustain;
-      } else {
-        startTime = currentTime;
-        stage = 3;
-      }
-      break;
-
-    case 3:  // Release
-      if (elapsedTime < T_release) {
-        envelopeValue = A_sustain * exp(-(elapsedTime / tau_release));
-      } else {
-        envelopeValue = 0;
-        stage = 4;
-      }
-      break;
-
-    case 4:  // Done
-      envelopeValue = 0;
-
-      // TEMP: Restart the envelope
-      startTime = currentTime;
-      stage = 0;
-      break;
+  if(elapsedTime > adsr.getEnvelopeDurationMs()) {
+    startTime = currentTime;
+    elapsedTime = 0;
   }
+
+  envelopeValue = adsr.getEnvelopeValue(elapsedTime);
 #if defined(ESP32)
   dacWrite(DAC1, envelopeValue);
 #else

--- a/adsr/adsr.ino
+++ b/adsr/adsr.ino
@@ -1,4 +1,5 @@
 #include "AdsrEnvelope.h"
+#include "Display.h"
 
 #if defined(ESP32)
 #include <ESP32Encoder.h>
@@ -35,6 +36,7 @@ enum EncoderState {
 };
 
 volatile EncoderState encoderState = ATTACK_DURATION;
+Display display(240, 135);
 
 long encoderPosition = 0;
 
@@ -58,6 +60,8 @@ void setup() {
 
   pinMode(ENCODER_BUTTON_PIN, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(ENCODER_BUTTON_PIN), handleSwitch, RISING);
+
+  display.init();
 
   // pinMode(buzzPin, OUTPUT);
   // tone(buzzPin, 200);
@@ -105,6 +109,7 @@ void loop() {
             Serial.println(attackShapeFactor);
             break;
         }
+        display.drawChart(&adsr);
    }
 
   unsigned long currentTime = millis();

--- a/adsr/adsr.ino
+++ b/adsr/adsr.ino
@@ -89,8 +89,8 @@ void loop() {
             attackDurationMs += 50 * encoderDelta;
             if (attackDurationMs > 1000) {
                 attackDurationMs = 1000;
-            } else if (attackDurationMs < 0) {
-                attackDurationMs = 0;
+            } else if (attackDurationMs < 100) {
+                attackDurationMs = 50;
             }
             adsr.setAttackDurationMs(attackDurationMs);
             Serial.print("Attack duration: ");
@@ -109,7 +109,7 @@ void loop() {
             Serial.println(attackShapeFactor);
             break;
         }
-        display.drawChart(&adsr);
+        display.draw(&adsr);
    }
 
   unsigned long currentTime = millis();

--- a/adsr/adsr.ino
+++ b/adsr/adsr.ino
@@ -39,6 +39,7 @@ void setup() {
   display.init();
   encoderHandler.registerOnEncoderChange(onEncoderChanged);
   encoderHandler.setup();
+  display.draw(&adsr);
 }
 
 void loop() {

--- a/adsr/adsr.ino
+++ b/adsr/adsr.ino
@@ -36,7 +36,7 @@ void setup() {
 #endif
 
   // Initialize the envelope stage
-  startTime = millis();
+  adsr.setEnvelopeStartTime(millis());
 
   Serial.println("Hello Envelope Generator");
 
@@ -67,13 +67,13 @@ void loop() {
 //   }
 
   unsigned long currentTime = millis();
-  unsigned long elapsedTime = currentTime - startTime;
-  if(elapsedTime > adsr.getEnvelopeDurationMs()) {
-    startTime = currentTime;
-    elapsedTime = 0;
+
+  // For now, automatically trigger a new adsr envelope once the previous one has finished
+  if(currentTime > adsr.getEnvelopeStartTime() + adsr.getEnvelopeDurationMs()) {
+    adsr.setEnvelopeStartTime(currentTime);
   }
 
-  envelopeValue = adsr.getEnvelopeValue(elapsedTime);
+  envelopeValue = adsr.getEnvelopeValue(currentTime);
 #if defined(ESP32)
   dacWrite(DAC1, envelopeValue);
 #else

--- a/adsr/adsr.ino
+++ b/adsr/adsr.ino
@@ -1,55 +1,33 @@
 #include "AdsrEnvelope.h"
 #include "Display.h"
+#include "EncoderHandler.h"
 
 #if defined(ESP32)
-#include <ESP32Encoder.h>
 #define DAC_BIT_WIDTH 8
-#define ENCODER_A_PIN 32
-#define ENCODER_B_PIN 33
-#define ENCODER_BUTTON_PIN 26
-void IRAM_ATTR handleSwitch();
-
-ESP32Encoder encoder;
 #else
-#include <Encoder.h>
-#define ENCODER_A_PIN 5
-#define ENCODER_B_PIN 6
 #define DAC_BIT_WIDTH 12
-#define ENCODER_BUTTON_PIN 7
-
-Encoder encoder(ENCODER_A_PIN, ENCODER_B_PIN);
 #endif
-
-const int A_max = (1 << DAC_BIT_WIDTH) - 1;  // 4095 on 12 bit DAC
-const int A_sustain = A_max * 0.75;
-unsigned long T_attack = 100;         // Attack time in milliseconds
-const unsigned long T_decay = 75;     // Decay time in milliseconds
-const unsigned long T_sustain = 250;  // Sustain time in milliseconds
-const unsigned long T_release = 250;  // Release time in milliseconds
 
 int envelopeValue = 0;
 unsigned long startTime = 0;
 
-enum EncoderState {
-  ATTACK_DURATION,
-  ATTACK_SHAPE
-};
-
-volatile EncoderState encoderState = ATTACK_DURATION;
+uint16_t A_max = (1 << DAC_BIT_WIDTH) - 1;
+AdsrEnvelope adsr(
+    A_max, // 4095 on 12 bit DAC
+    100, // T_attack
+    75, // T_decay
+    250, // T_sustain
+    A_max * 0.75, //  A_sustain
+    250 // T_release
+    );
 Display display(240, 135);
-
-long encoderPosition = 0;
-
-const byte buzzPin = 3;
-
-AdsrEnvelope adsr(A_max, T_attack, T_decay, T_sustain, A_sustain, T_release);
+EncoderHandler encoderHandler(&adsr);
 
 void setup() {
   Serial.begin(115200);
 
 #if defined(ESP32)
   delay(1000);  // wait for Serial on ESP32
-  encoder.attachHalfQuad(ENCODER_A_PIN, ENCODER_B_PIN);
 #else
   analogWriteResolution(DAC_BIT_WIDTH);  // Max out DAC resolution
 #endif
@@ -58,60 +36,12 @@ void setup() {
 
   Serial.println("Hello Envelope Generator");
 
-  pinMode(ENCODER_BUTTON_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(ENCODER_BUTTON_PIN), handleSwitch, RISING);
-
   display.init();
-
-  // pinMode(buzzPin, OUTPUT);
-  // tone(buzzPin, 200);
+  encoderHandler.registerOnEncoderChange(onEncoderChanged);
+  encoderHandler.setup();
 }
 
 void loop() {
-
-    #if defined(ESP32)
-    long newEncoderPosition = encoder.getCount() / 2;
-    #else
-    long newEncoderPosition = encoder.read() / 4;
-    #endif
-
-    if (newEncoderPosition != encoderPosition) {
-        Serial.print("Encoder position: ");
-        Serial.println(newEncoderPosition);
-
-        long encoderDelta = (newEncoderPosition - encoderPosition);
-        encoderPosition = newEncoderPosition;
-        double attackDurationMs;
-        double attackShapeFactor;
-        switch (encoderState) {
-        case ATTACK_DURATION:
-            attackDurationMs = adsr.getAttackDurationMs();
-            attackDurationMs += 50 * encoderDelta;
-            if (attackDurationMs > 1000) {
-                attackDurationMs = 1000;
-            } else if (attackDurationMs < 100) {
-                attackDurationMs = 50;
-            }
-            adsr.setAttackDurationMs(attackDurationMs);
-            Serial.print("Attack duration: ");
-            Serial.println(attackDurationMs);
-            break;
-        case ATTACK_SHAPE:
-            attackShapeFactor = adsr.getAttackShapeFactor();
-            attackShapeFactor += 0.5 * encoderDelta;
-            if (attackShapeFactor > 10) {
-                attackShapeFactor = 10;
-            } else if (attackShapeFactor < 4) {
-                attackShapeFactor = 4;
-            }
-            adsr.setAttackShapeFactor(attackShapeFactor);
-            Serial.print("Attack shape factor: ");
-            Serial.println(attackShapeFactor);
-            break;
-        }
-        display.draw(&adsr);
-   }
-
   unsigned long currentTime = millis();
 
   // For now, automatically trigger a new adsr envelope once the previous one has finished
@@ -120,6 +50,9 @@ void loop() {
   }
 
   envelopeValue = adsr.getEnvelopeValue(currentTime);
+
+  encoderHandler.tick();
+
 #if defined(ESP32)
   dacWrite(DAC1, envelopeValue);
 #else
@@ -127,12 +60,6 @@ void loop() {
 #endif
 }
 
-#if defined(ESP32)
-void IRAM_ATTR handleSwitch() {
-# else
-void handleSwitch() {
-#endif
-  // note: not okay to call Serial.println method on ESP32 here as it blocks.
-  // TODO: probably need to debounce.
-  encoderState = (EncoderState)((encoderState + 1) % 2);
+void onEncoderChanged() {
+  display.draw(&adsr);
 }


### PR DESCRIPTION
In this PR

* refactored the existing envelope calculations to the AdsrEnvelope class. 
* added support for linear curves when the phase factor is less than 5.
* added encoder support for adjusting the attack part of the curve (duration and shape)
* added screen output

This PR was written with targeting other devices in mind, but is only set up for the ESP32 / LilyGo TTGO board. Support for other devices will need to be added by judicious use of #if defined.